### PR TITLE
Prototype stats insights page

### DIFF
--- a/grail-client/src/App.tsx
+++ b/grail-client/src/App.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import AppShell from './components/AppShell'
 import ItemsPage from './features/items/ItemsPage'
+import StatsPage from './features/stats/StatsPage'
 import SetsRunewordsPage from './features/sets/SetsRunewordsPage'
 import './App.css'
 
@@ -23,12 +24,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'stats',
-        element: (
-          <ComingSoon
-            title="Stats & Insights"
-            description="Visualize drop trends and collection milestones with charts and heatmaps."
-          />
-        ),
+        element: <StatsPage />,
       },
       {
         path: 'settings',

--- a/grail-client/src/features/stats/StatsPage.css
+++ b/grail-client/src/features/stats/StatsPage.css
@@ -1,0 +1,202 @@
+.stats-page {
+  gap: var(--space-2xl);
+}
+
+.stats-page__header {
+  max-width: 60rem;
+}
+
+.stats-page__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.stats-section-title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+}
+
+.stats-section-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.stats-metrics {
+  align-items: stretch;
+}
+
+.stats-metric-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.stats-metric-card__value {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.stats-metric-card__number {
+  font-size: var(--font-size-2xl);
+  font-weight: 600;
+}
+
+.stats-metric-card__delta {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.stats-metric-card__progress {
+  position: relative;
+  height: 0.75rem;
+  border-radius: var(--radius-full);
+  background: var(--surface-muted);
+  overflow: hidden;
+}
+
+.stats-metric-card__progress-bar {
+  position: absolute;
+  inset: 0;
+  width: var(--value, 0%);
+  background: linear-gradient(90deg, #d97706, #fbbf24);
+  transition: width 160ms ease-in-out;
+}
+
+.stats-chart-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.chart-area {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(63, 63, 70, 0.7), rgba(39, 39, 42, 0.7));
+  border: 1px dashed rgba(250, 204, 21, 0.4);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.chart-area__sparkline {
+  width: 90%;
+  height: 40%;
+  background: linear-gradient(90deg, rgba(251, 191, 36, 0.2), rgba(250, 204, 21, 0.7));
+  border-radius: var(--radius-md);
+  mask: repeating-linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0) 0,
+    rgba(0, 0, 0, 0) 6%,
+    rgba(0, 0, 0, 1) 6%,
+    rgba(0, 0, 0, 1) 12%
+  );
+}
+
+.chart-insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: var(--space-md);
+  margin: 0;
+}
+
+.chart-insights > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.chart-insights dt {
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.chart-insights dd {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.hotspot-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.hotspot-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.hotspot-card__badge {
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-full);
+  background: rgba(96, 165, 250, 0.16);
+  color: #93c5fd;
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hotspot-card__score {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+}
+
+.hotspot-card__hint {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.milestone-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.milestone-card__progress {
+  position: relative;
+  height: 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--surface-muted);
+  overflow: hidden;
+}
+
+.milestone-card__progress-bar {
+  position: absolute;
+  inset: 0;
+  width: var(--value, 0%);
+  background: linear-gradient(90deg, #0ea5e9, #6366f1);
+}
+
+.milestone-card__details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.milestone-card__eta {
+  font-weight: 600;
+}
+
+.milestone-card__blockers {
+  margin: 0;
+  padding-left: var(--space-lg);
+  color: var(--text-muted);
+}
+
+.milestone-card__blockers li + li {
+  margin-top: var(--space-2xs);
+}
+
+@media (max-width: 720px) {
+  .chart-area {
+    aspect-ratio: 4 / 3;
+  }
+}

--- a/grail-client/src/features/stats/StatsPage.tsx
+++ b/grail-client/src/features/stats/StatsPage.tsx
@@ -1,0 +1,388 @@
+import { useMemo, useState } from 'react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+  FilterChip,
+  Grid,
+  Stack,
+} from '../../components/ui'
+import { classNames } from '../../lib/classNames'
+import './StatsPage.css'
+
+type CompletionMetric = {
+  id: string
+  label: string
+  value: number
+  total: number
+  delta: number
+  description: string
+  unit: 'count' | 'percent'
+}
+
+type DropHistoryPoint = {
+  date: string
+  totalFinds: number
+  uniques: number
+  sets: number
+  runes: number
+}
+
+type Timeframe = '7d' | '30d' | '90d'
+
+const COMPLETION_METRICS: CompletionMetric[] = [
+  {
+    id: 'uniques',
+    label: 'Unique items logged',
+    value: 137,
+    total: 377,
+    delta: 9,
+    description: 'How many unique-tier drops you have recorded so far.',
+    unit: 'count',
+  },
+  {
+    id: 'sets',
+    label: 'Set pieces secured',
+    value: 92,
+    total: 127,
+    delta: 6,
+    description: 'Progress toward assembling every set piece across difficulties.',
+    unit: 'count',
+  },
+  {
+    id: 'runewords',
+    label: 'Runewords completed',
+    value: 23,
+    total: 78,
+    delta: 2,
+    description: 'Finished runewords that met level requirements and rune ownership.',
+    unit: 'count',
+  },
+  {
+    id: 'overall',
+    label: 'Overall grail completion',
+    value: 36,
+    total: 100,
+    delta: 2,
+    description: 'Blended completion score factoring uniques, sets, and runewords.',
+    unit: 'percent',
+  },
+]
+
+const DROP_HISTORY: DropHistoryPoint[] = [
+  { date: '2024-03-10', totalFinds: 6, uniques: 3, sets: 2, runes: 1 },
+  { date: '2024-03-17', totalFinds: 9, uniques: 4, sets: 3, runes: 2 },
+  { date: '2024-03-24', totalFinds: 7, uniques: 3, sets: 2, runes: 2 },
+  { date: '2024-03-31', totalFinds: 12, uniques: 5, sets: 4, runes: 3 },
+  { date: '2024-04-07', totalFinds: 8, uniques: 4, sets: 2, runes: 2 },
+  { date: '2024-04-14', totalFinds: 11, uniques: 5, sets: 3, runes: 3 },
+  { date: '2024-04-21', totalFinds: 13, uniques: 6, sets: 4, runes: 3 },
+  { date: '2024-04-28', totalFinds: 10, uniques: 4, sets: 3, runes: 3 },
+  { date: '2024-05-05', totalFinds: 14, uniques: 6, sets: 5, runes: 3 },
+  { date: '2024-05-12', totalFinds: 9, uniques: 4, sets: 3, runes: 2 },
+  { date: '2024-05-19', totalFinds: 15, uniques: 7, sets: 4, runes: 4 },
+  { date: '2024-05-26', totalFinds: 18, uniques: 8, sets: 6, runes: 4 },
+]
+
+const TIMEFRAME_LENGTH: Record<Timeframe, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+}
+
+type DropMetricKey = 'totalFinds' | 'uniques' | 'sets' | 'runes'
+
+const DROP_METRIC_OPTIONS: { key: DropMetricKey; label: string; description: string }[] = [
+  {
+    key: 'totalFinds',
+    label: 'All finds',
+    description: 'Every tracked grail drop across categories.',
+  },
+  {
+    key: 'uniques',
+    label: 'Uniques',
+    description: 'Unique-tier drops by session.',
+  },
+  {
+    key: 'sets',
+    label: 'Set items',
+    description: 'Tracked set piece finds by session.',
+  },
+  {
+    key: 'runes',
+    label: 'Runes',
+    description: 'Rune drops that matter for runewords.',
+  },
+]
+
+type FarmingHotspot = {
+  id: string
+  location: string
+  difficulty: 'Normal' | 'Nightmare' | 'Hell'
+  efficiencyScore: number
+  bestFor: string
+  recentFinds: number
+}
+
+const FARMING_HOTSPOTS: FarmingHotspot[] = [
+  {
+    id: 'pit-hell',
+    location: 'The Pit — Tamoe Highland',
+    difficulty: 'Hell',
+    efficiencyScore: 94,
+    bestFor: 'High level uniques, socket bases',
+    recentFinds: 7,
+  },
+  {
+    id: 'andy-nightmare',
+    location: "Andariel Runs",
+    difficulty: 'Nightmare',
+    efficiencyScore: 82,
+    bestFor: 'Set jewelry, mid-tier uniques',
+    recentFinds: 5,
+  },
+  {
+    id: 'cow-hell',
+    location: 'Secret Cow Level',
+    difficulty: 'Hell',
+    efficiencyScore: 76,
+    bestFor: 'Runes, base items',
+    recentFinds: 6,
+  },
+  {
+    id: 'trav-hell',
+    location: 'Travincal Council',
+    difficulty: 'Hell',
+    efficiencyScore: 71,
+    bestFor: 'High runes, unique jewelry',
+    recentFinds: 4,
+  },
+]
+
+type MilestoneProjection = {
+  id: string
+  title: string
+  description: string
+  completionPercent: number
+  eta: string
+  blockers: string[]
+}
+
+const MILESTONE_PROJECTIONS: MilestoneProjection[] = [
+  {
+    id: 'unique-75',
+    title: 'Reach 75% unique completion',
+    description: 'Prioritize TC 84 zones to close the remaining high-tier uniques.',
+    completionPercent: 62,
+    eta: 'Targeting 3 weeks',
+    blockers: ['Need Stormlash or equivalent high rune drops'],
+  },
+  {
+    id: 'runeword-30',
+    title: 'Craft 30 runewords',
+    description: 'Focus on farming Gul+ runes and finding ethereal bases.',
+    completionPercent: 48,
+    eta: 'Stretch goal in 5 weeks',
+    blockers: ['Lacking Vex and Ohm runes', 'Need 4os ethereal polearm'],
+  },
+  {
+    id: 'set-complete',
+    title: 'Finish Tal Rasha\'s Wrappings',
+    description: 'Set-targeted farming for amulet and armor variants.',
+    completionPercent: 80,
+    eta: 'Likely this week',
+    blockers: ['Armor variants only drop in Hell difficulty'],
+  },
+]
+
+const TIMEFRAME_OPTIONS: { label: string; value: Timeframe }[] = [
+  { label: 'Last 7 days', value: '7d' },
+  { label: 'Last 30 days', value: '30d' },
+  { label: 'Last 90 days', value: '90d' },
+]
+
+function StatsPage() {
+  const [timeframe, setTimeframe] = useState<Timeframe>('30d')
+  const [dropMetric, setDropMetric] = useState<DropMetricKey>('totalFinds')
+
+  const sessionsWithinTimeframe = useMemo(() => {
+    const windowSize = TIMEFRAME_LENGTH[timeframe]
+    const endIndex = DROP_HISTORY.length
+    const startIndex = Math.max(0, endIndex - Math.ceil(windowSize / 7))
+    return DROP_HISTORY.slice(startIndex, endIndex)
+  }, [timeframe])
+
+  const totalDropsInWindow = sessionsWithinTimeframe.reduce((total, point) => total + point[dropMetric], 0)
+  const averageDropsPerRun = sessionsWithinTimeframe.length
+    ? totalDropsInWindow / sessionsWithinTimeframe.length
+    : 0
+
+  return (
+    <Container className="page stats-page" maxWidth="xl">
+      <header className="page__header stats-page__header">
+        <p className="page__eyebrow">Progress intelligence</p>
+        <h1>Stats &amp; Insights</h1>
+        <p className="page__lead">
+          Prototype visualizations that summarize grail completion, highlight farming hotspots, and suggest next actions.
+        </p>
+      </header>
+
+      <section className="stats-page__section">
+        <Stack direction="horizontal" gap="sm" wrap>
+          {TIMEFRAME_OPTIONS.map((option) => (
+            <FilterChip
+              key={option.value}
+              selected={timeframe === option.value}
+              onClick={() => setTimeframe(option.value)}
+            >
+              {option.label}
+            </FilterChip>
+          ))}
+        </Stack>
+
+        <Grid className="stats-metrics" minItemWidth="16rem" gap="lg">
+          {COMPLETION_METRICS.map((metric) => {
+            const percent = metric.unit === 'percent' ? metric.value : (metric.value / metric.total) * 100
+            return (
+              <Card key={metric.id} className="stats-metric-card" aria-live="polite">
+                <CardHeader>
+                  <CardTitle>{metric.label}</CardTitle>
+                  <CardDescription>{metric.description}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="stats-metric-card__value">
+                    <span className="stats-metric-card__number">
+                      {metric.unit === 'percent' ? `${metric.value}%` : `${metric.value} / ${metric.total}`}
+                    </span>
+                    <span className="stats-metric-card__delta">+{metric.delta} this window</span>
+                  </div>
+                  <div className="stats-metric-card__progress" role="img" aria-label={`Progress ${percent.toFixed(0)} percent`}>
+                    <div className="stats-metric-card__progress-bar" style={{ ['--value' as string]: `${percent}%` }} />
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </Grid>
+      </section>
+
+      <section className="stats-page__section">
+        <Stack direction="horizontal" justify="between" align="center" wrap gap="sm">
+          <div>
+            <h2 className="stats-section-title">Drop activity</h2>
+            <p className="stats-section-subtitle">Session-by-session breakdown of tracked finds.</p>
+          </div>
+          <Stack direction="horizontal" gap="xs" wrap align="center">
+            {DROP_METRIC_OPTIONS.map((option) => (
+              <FilterChip
+                key={option.key}
+                selected={dropMetric === option.key}
+                onClick={() => setDropMetric(option.key)}
+              >
+                {option.label}
+              </FilterChip>
+            ))}
+          </Stack>
+        </Stack>
+
+        <Card className="stats-chart-card">
+          <CardHeader>
+            <CardTitle>{DROP_METRIC_OPTIONS.find((option) => option.key === dropMetric)?.label}</CardTitle>
+            <CardDescription>
+              {DROP_METRIC_OPTIONS.find((option) => option.key === dropMetric)?.description}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div
+              className={classNames('chart-area', `chart-area--${dropMetric}`)}
+              role="img"
+              aria-label="Prototype line chart showing finds per run"
+            >
+              <div className="chart-area__sparkline" />
+            </div>
+            <dl className="chart-insights">
+              <div>
+                <dt>Sessions analyzed</dt>
+                <dd>{sessionsWithinTimeframe.length}</dd>
+              </div>
+              <div>
+                <dt>Total drops</dt>
+                <dd>{totalDropsInWindow}</dd>
+              </div>
+              <div>
+                <dt>Average per run</dt>
+                <dd>{averageDropsPerRun.toFixed(1)}</dd>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="stats-page__section">
+        <h2 className="stats-section-title">Farming hotspots</h2>
+        <p className="stats-section-subtitle">
+          Candidate zones ranked by recent efficiency so we can model recommended runs.
+        </p>
+        <Grid minItemWidth="20rem" gap="md">
+          {FARMING_HOTSPOTS.map((hotspot) => (
+            <Card key={hotspot.id} className="hotspot-card">
+              <CardHeader>
+                <CardTitle>{hotspot.location}</CardTitle>
+                <CardDescription>{hotspot.bestFor}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="hotspot-card__meta">
+                  <span className="hotspot-card__badge">{hotspot.difficulty}</span>
+                  <span className="hotspot-card__score" aria-label="Efficiency score">
+                    {hotspot.efficiencyScore}
+                  </span>
+                </div>
+                <p className="hotspot-card__hint">
+                  Logged {hotspot.recentFinds} qualifying drops this timeframe. Use this to feed routing suggestions.
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </Grid>
+      </section>
+
+      <section className="stats-page__section">
+        <h2 className="stats-section-title">Milestone projections</h2>
+        <p className="stats-section-subtitle">
+          Future-focused goals with blockers to surface next best actions.
+        </p>
+        <Stack gap="md">
+          {MILESTONE_PROJECTIONS.map((milestone) => (
+            <Card key={milestone.id} className="milestone-card">
+              <CardHeader>
+                <CardTitle>{milestone.title}</CardTitle>
+                <CardDescription>{milestone.description}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="milestone-card__progress" role="img" aria-label={`Completion ${milestone.completionPercent} percent`}>
+                  <div
+                    className="milestone-card__progress-bar"
+                    style={{ ['--value' as string]: `${milestone.completionPercent}%` }}
+                  />
+                </div>
+                <div className="milestone-card__details">
+                  <span className="milestone-card__eta">{milestone.eta}</span>
+                  <ul className="milestone-card__blockers">
+                    {milestone.blockers.map((blocker) => (
+                      <li key={blocker}>{blocker}</li>
+                    ))}
+                  </ul>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      </section>
+    </Container>
+  )
+}
+
+export default StatsPage


### PR DESCRIPTION
## Summary
- replace the Stats & Insights route placeholder with a prototype page
- outline collection metrics, drop history filters, hotspot rankings, and milestone projections with stub data
- add styling for chart placeholders and progress visuals so we can discuss interactions and required data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35854fffc832885f927e319c399a8