### PR TITLE
Expand Stats & Insights follow-up tasks

### DIFF
--- a/TODO
+++ b/TODO
@@ -71,6 +71,9 @@
   - Prototype drop-source heatmap and act progression timelines (lightweight SVG)
   - Provide export/share controls for progress summaries (image + CSV)
   - Prioritize prototype to drive metrics requirements
+  - Replace placeholder drop activity visualization with a real chart wired to the selected metric
+  - Feed cards and charts from live profile statistics instead of hard-coded demo data
+  - Author dynamic insight copy that highlights notable trends or outliers from the player's recent runs
 ☐ Refresh settings & data management
   - Organize account, appearance, data, and onboarding sections with inline forms
   - Add theme toggles (dark, light, high-contrast) and sync status indicators


### PR DESCRIPTION
## Summary
- add concrete follow-up actions for the Stats & Insights page
- note the need for live data, a real drop activity chart, and responsive insight copy

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d35d6aede883289325a7d347896b97