### PR TITLE
Add real drop activity chart

### DIFF
--- a/grail-client/src/features/stats/StatsPage.css
+++ b/grail-client/src/features/stats/StatsPage.css
@@ -70,29 +70,75 @@
   gap: var(--space-md);
 }
 
-.chart-area {
-  position: relative;
-  aspect-ratio: 16 / 9;
+.drop-chart {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.drop-chart__surface {
   border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, rgba(63, 63, 70, 0.7), rgba(39, 39, 42, 0.7));
-  border: 1px dashed rgba(250, 204, 21, 0.4);
-  display: grid;
-  place-items: center;
+  border: 1px solid rgba(250, 204, 21, 0.25);
+  background: radial-gradient(circle at 20% 20%, rgba(250, 204, 21, 0.1), transparent 60%),
+    linear-gradient(135deg, rgba(63, 63, 70, 0.6), rgba(17, 24, 39, 0.8));
+  padding: var(--space-xs);
   overflow: hidden;
 }
 
-.chart-area__sparkline {
-  width: 90%;
-  height: 40%;
-  background: linear-gradient(90deg, rgba(251, 191, 36, 0.2), rgba(250, 204, 21, 0.7));
-  border-radius: var(--radius-md);
-  mask: repeating-linear-gradient(
-    to right,
-    rgba(0, 0, 0, 0) 0,
-    rgba(0, 0, 0, 0) 6%,
-    rgba(0, 0, 0, 1) 6%,
-    rgba(0, 0, 0, 1) 12%
-  );
+.drop-chart__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.drop-chart__grid-line {
+  stroke: rgba(148, 163, 184, 0.15);
+  stroke-width: 1;
+}
+
+.drop-chart__axis {
+  stroke: rgba(148, 163, 184, 0.35);
+  stroke-width: 1.5;
+}
+
+.drop-chart__line {
+  fill: none;
+  stroke: #facc15;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.drop-chart__area {
+  opacity: 0.45;
+}
+
+.drop-chart__point {
+  fill: #facc15;
+  stroke: rgba(24, 24, 27, 0.85);
+  stroke-width: 2;
+}
+
+.drop-chart__axis-label {
+  fill: rgba(226, 232, 240, 0.8);
+  font-size: var(--font-size-xs);
+}
+
+.drop-chart__caption {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.drop-chart--empty {
+  display: grid;
+  place-items: center;
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, rgba(63, 63, 70, 0.3), rgba(39, 39, 42, 0.3));
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .chart-insights {
@@ -196,7 +242,7 @@
 }
 
 @media (max-width: 720px) {
-  .chart-area {
-    aspect-ratio: 4 / 3;
+  .drop-chart__surface {
+    padding: var(--space-2xs);
   }
 }


### PR DESCRIPTION
## Summary
- replace the drop activity placeholder with an SVG line chart bound to the selected metric
- surface accessible labelling, tick marks, and hover titles for each weekly datapoint
- refresh the stats styles to support the chart surface, empty state, and caption

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d360fbeedc8328a4f533d1e84f4907