### PR TITLE
Add authentication flows to client shell

### DIFF
--- a/grail-client/src/components/AppShell.css
+++ b/grail-client/src/components/AppShell.css
@@ -44,7 +44,17 @@
 .app-bar__nav {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-sm);
+  flex: 1;
+  min-width: 0;
+}
+
+.app-bar__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 220px;
 }
 
 .app-bar__link {
@@ -94,6 +104,11 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: var(--space-xs);
+  }
+
+  .app-bar__actions {
+    width: 100%;
+    min-width: 0;
   }
 
   .app-bar__link {

--- a/grail-client/src/components/AppShell.tsx
+++ b/grail-client/src/components/AppShell.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom'
+import AuthMenu from '../features/auth/AuthMenu'
 import './AppShell.css'
 
 const NAV_LINKS = [
@@ -29,6 +30,9 @@ function AppShell() {
             </NavLink>
           ))}
         </nav>
+        <div className="app-bar__actions">
+          <AuthMenu />
+        </div>
       </header>
 
       <main className="app-shell__main">

--- a/grail-client/src/features/auth/AuthContext.tsx
+++ b/grail-client/src/features/auth/AuthContext.tsx
@@ -1,0 +1,147 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  fetchCurrentUser,
+  loginUser,
+  registerUser,
+  type AuthResponse,
+  type AuthUser,
+  type LoginInput,
+  type RegisterInput,
+} from './authApi'
+import { clearAuthToken, getAuthToken, setAuthToken } from '../../lib/authToken'
+
+type AuthContextValue = {
+  user: AuthUser | null
+  token: string | null
+  isLoading: boolean
+  isAuthenticated: boolean
+  login: (input: LoginInput) => Promise<AuthResponse>
+  register: (input: RegisterInput) => Promise<AuthResponse>
+  logout: () => void
+  refreshUser: () => Promise<AuthUser | null>
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+type AuthStatus = 'idle' | 'loading' | 'authenticated'
+
+type AuthProviderProps = {
+  children: ReactNode
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+  const [status, setStatus] = useState<AuthStatus>('idle')
+
+  useEffect(() => {
+    const existingToken = getAuthToken()
+    if (!existingToken) {
+      setStatus('idle')
+      return
+    }
+
+    setToken(existingToken)
+    setStatus('loading')
+    fetchCurrentUser()
+      .then((current) => {
+        setUser(current)
+        setStatus('authenticated')
+      })
+      .catch(() => {
+        clearAuthToken()
+        setToken(null)
+        setUser(null)
+        setStatus('idle')
+      })
+  }, [])
+
+  const persistAuth = useCallback((response: AuthResponse) => {
+    setToken(response.token)
+    setUser(response.user)
+    setAuthToken(response.token)
+    setStatus('authenticated')
+    return response
+  }, [])
+
+  const login = useCallback(async (input: LoginInput) => {
+    setStatus('loading')
+    try {
+      const response = await loginUser(input)
+      return persistAuth(response)
+    } catch (error) {
+      setStatus(token ? 'authenticated' : 'idle')
+      throw error
+    }
+  }, [persistAuth, token])
+
+  const register = useCallback(async (input: RegisterInput) => {
+    setStatus('loading')
+    try {
+      const response = await registerUser(input)
+      return persistAuth(response)
+    } catch (error) {
+      setStatus(token ? 'authenticated' : 'idle')
+      throw error
+    }
+  }, [persistAuth, token])
+
+  const logout = useCallback(() => {
+    clearAuthToken()
+    setToken(null)
+    setUser(null)
+    setStatus('idle')
+  }, [])
+
+  const refreshUser = useCallback(async () => {
+    if (!getAuthToken()) {
+      setUser(null)
+      setToken(null)
+      setStatus('idle')
+      return null
+    }
+
+    setStatus('loading')
+    try {
+      const current = await fetchCurrentUser()
+      setUser(current)
+      setStatus('authenticated')
+      return current
+    } catch (error) {
+      logout()
+      throw error
+    }
+  }, [logout])
+
+  const value = useMemo<AuthContextValue>(() => {
+    return {
+      user,
+      token,
+      isLoading: status === 'loading',
+      isAuthenticated: status === 'authenticated',
+      login,
+      register,
+      logout,
+      refreshUser,
+    }
+  }, [login, logout, refreshUser, register, status, token, user])
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/grail-client/src/features/auth/AuthMenu.css
+++ b/grail-client/src/features/auth/AuthMenu.css
@@ -1,0 +1,152 @@
+.auth-menu {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
+.auth-menu__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.auth-menu__status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-full);
+  background: rgba(59, 130, 246, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.28);
+}
+
+.auth-menu__details {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space-2xs) * 0.75);
+}
+
+.auth-menu__eyebrow {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.auth-menu__user {
+  font-weight: 600;
+}
+
+.auth-menu__popover {
+  position: absolute;
+  top: calc(100% + var(--space-sm));
+  right: 0;
+  width: min(360px, 90vw);
+  z-index: 20;
+}
+
+.auth-form {
+  width: 100%;
+}
+
+.auth-form__card {
+  backdrop-filter: blur(18px);
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(56, 189, 248, 0.24);
+  box-shadow: 0 28px 60px rgba(3, 7, 18, 0.45);
+}
+
+.auth-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  font-size: var(--font-size-sm);
+}
+
+.auth-form__field span {
+  font-weight: 600;
+}
+
+.auth-form__field input {
+  padding: calc(var(--space-xs) * 0.9) var(--space-sm);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font: inherit;
+}
+
+.auth-form__field input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.auth-form__hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.auth-form__error {
+  margin: 0;
+  padding: calc(var(--space-2xs) * 1.2) var(--space-sm);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.25);
+  color: #fecaca;
+  font-size: var(--font-size-xs);
+}
+
+.auth-form__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-lg);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: var(--font-size-xs);
+}
+
+.auth-form__footer p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.auth-form__swap {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: 600;
+  color: var(--accent-arcane);
+  cursor: pointer;
+}
+
+.auth-form__swap:hover {
+  color: var(--color-arcane-500);
+}
+
+@media (max-width: 720px) {
+  .auth-menu {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .auth-menu__status {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .auth-menu__actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .auth-menu__popover {
+    right: auto;
+    left: 0;
+  }
+}

--- a/grail-client/src/features/auth/AuthMenu.tsx
+++ b/grail-client/src/features/auth/AuthMenu.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Stack } from '../../components/ui'
+import { classNames } from '../../lib/classNames'
+import { getApiErrorMessage } from '../../lib/apiClient'
+import { useAuth } from './AuthContext'
+import './AuthMenu.css'
+
+type ActiveForm = 'login' | 'signup' | null
+
+type BaseFormProps = {
+  onSuccess: () => void
+  onSwap: () => void
+}
+
+function LoginForm({ onSuccess, onSwap }: BaseFormProps) {
+  const { login } = useAuth()
+  const [usernameOrEmail, setUsernameOrEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await login({ usernameOrEmail, password })
+      onSuccess()
+    } catch (caught) {
+      setError(getApiErrorMessage(caught, 'Unable to sign in. Please try again.'))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const canSubmit = usernameOrEmail.trim().length > 0 && password.trim().length > 0
+
+  return (
+    <form className="auth-form" onSubmit={handleSubmit}>
+      <Card className="auth-form__card">
+        <CardHeader>
+          <CardTitle>Welcome back</CardTitle>
+          <CardDescription>Sign in to sync your grail progress across devices.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Stack gap="sm">
+            <label className="auth-form__field">
+              <span>Username or email</span>
+            <input
+              type="text"
+              name="usernameOrEmail"
+              autoComplete="username"
+              value={usernameOrEmail}
+              onChange={(event) => setUsernameOrEmail(event.target.value)}
+              required
+            />
+          </label>
+          <label className="auth-form__field">
+            <span>Password</span>
+            <input
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </label>
+          {error && <p className="auth-form__error" role="alert">{error}</p>}
+          <Button type="submit" size="sm" loading={isSubmitting} disabled={!canSubmit}>
+            Log in
+          </Button>
+        </Stack>
+        </CardContent>
+        <div className="auth-form__footer">
+          <p>New to Grail Tracker?</p>
+          <button type="button" onClick={onSwap} className="auth-form__swap">
+            Create an account
+          </button>
+        </div>
+      </Card>
+    </form>
+  )
+}
+
+function SignupForm({ onSuccess, onSwap }: BaseFormProps) {
+  const { register } = useAuth()
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await register({ username, email, password })
+      onSuccess()
+    } catch (caught) {
+      setError(getApiErrorMessage(caught, 'Unable to create your account. Please try again.'))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const canSubmit = username.trim().length > 0 && password.trim().length >= 8 && email.trim().length > 0
+
+  return (
+    <form className="auth-form" onSubmit={handleSubmit}>
+      <Card className="auth-form__card">
+        <CardHeader>
+          <CardTitle>Join the hunt</CardTitle>
+          <CardDescription>Track drops, sync rune ownership, and share progress with friends.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Stack gap="sm">
+            <label className="auth-form__field">
+              <span>Username</span>
+            <input
+              type="text"
+              name="username"
+              autoComplete="username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              required
+            />
+          </label>
+          <label className="auth-form__field">
+            <span>Email</span>
+            <input
+              type="email"
+              name="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </label>
+          <label className="auth-form__field">
+            <span>Password</span>
+            <input
+              type="password"
+              name="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              minLength={8}
+            />
+          </label>
+          <p className="auth-form__hint">Use at least 8 characters for the best security.</p>
+          {error && <p className="auth-form__error" role="alert">{error}</p>}
+          <Button type="submit" size="sm" loading={isSubmitting} disabled={!canSubmit}>
+            Sign up
+          </Button>
+        </Stack>
+        </CardContent>
+        <div className="auth-form__footer">
+          <p>Already have an account?</p>
+          <button type="button" onClick={onSwap} className="auth-form__swap">
+            Log in instead
+          </button>
+        </div>
+      </Card>
+    </form>
+  )
+}
+
+function AuthMenu() {
+  const { isAuthenticated, isLoading, user, logout } = useAuth()
+  const [activeForm, setActiveForm] = useState<ActiveForm>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      setActiveForm(null)
+    }
+  }, [isAuthenticated])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setActiveForm(null)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  useEffect(() => {
+    if (!activeForm) {
+      return
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current) {
+        return
+      }
+      if (!containerRef.current.contains(event.target as Node)) {
+        setActiveForm(null)
+      }
+    }
+
+    window.addEventListener('mousedown', handleClick)
+    return () => window.removeEventListener('mousedown', handleClick)
+  }, [activeForm])
+
+  const toggleForm = useCallback((form: Exclude<ActiveForm, null>) => {
+    setActiveForm((current) => (current === form ? null : form))
+  }, [])
+
+  const form = useMemo(() => {
+    if (activeForm === 'login') {
+      return <LoginForm onSuccess={() => setActiveForm(null)} onSwap={() => setActiveForm('signup')} />
+    }
+    if (activeForm === 'signup') {
+      return <SignupForm onSuccess={() => setActiveForm(null)} onSwap={() => setActiveForm('login')} />
+    }
+    return null
+  }, [activeForm])
+
+  const showForm = Boolean(form)
+
+  return (
+    <div ref={containerRef} className={classNames('auth-menu', showForm && 'auth-menu--open')}>
+      {isAuthenticated && user ? (
+        <div className="auth-menu__status">
+          <div className="auth-menu__details">
+            <span className="auth-menu__eyebrow">Signed in</span>
+            <span className="auth-menu__user">{user.username}</span>
+          </div>
+          <Button variant="secondary" size="sm" onClick={logout} disabled={isLoading}>
+            Log out
+          </Button>
+        </div>
+      ) : (
+        <div className="auth-menu__actions">
+          <Button size="sm" variant="surface" onClick={() => toggleForm('login')}>
+            Log in
+          </Button>
+          <Button size="sm" onClick={() => toggleForm('signup')}>
+            Sign up
+          </Button>
+        </div>
+      )}
+      {showForm && <div className="auth-menu__popover">{form}</div>}
+    </div>
+  )
+}
+
+export default AuthMenu

--- a/grail-client/src/features/auth/authApi.ts
+++ b/grail-client/src/features/auth/authApi.ts
@@ -1,0 +1,43 @@
+import { apiRequest } from '../../lib/apiClient'
+
+export type AuthUser = {
+  id: number
+  username: string
+  email: string
+  createdAt: string
+  role: string
+}
+
+export type AuthResponse = {
+  token: string
+  user: AuthUser
+}
+
+export type RegisterInput = {
+  username: string
+  email: string
+  password: string
+}
+
+export type LoginInput = {
+  usernameOrEmail: string
+  password: string
+}
+
+export async function registerUser(input: RegisterInput): Promise<AuthResponse> {
+  return apiRequest<AuthResponse>('/auth/register', {
+    method: 'POST',
+    body: input,
+  })
+}
+
+export async function loginUser(input: LoginInput): Promise<AuthResponse> {
+  return apiRequest<AuthResponse>('/auth/login', {
+    method: 'POST',
+    body: input,
+  })
+}
+
+export async function fetchCurrentUser(): Promise<AuthUser> {
+  return apiRequest<AuthUser>('/auth/me')
+}

--- a/grail-client/src/lib/apiClient.ts
+++ b/grail-client/src/lib/apiClient.ts
@@ -1,3 +1,5 @@
+import { getAuthToken } from './authToken'
+
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
 export type ApiRequestOptions = {
@@ -29,10 +31,12 @@ const API_BASE_URL = '/api'
 
 function buildRequestInit(options: ApiRequestOptions = {}): RequestInit {
   const { method = 'GET', headers = {}, body, signal } = options
+  const token = getAuthToken()
   const init: RequestInit = {
     method,
     headers: {
       ...(body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...headers,
     },
     signal,

--- a/grail-client/src/lib/authToken.ts
+++ b/grail-client/src/lib/authToken.ts
@@ -1,0 +1,43 @@
+const STORAGE_KEY = 'grail-auth-token'
+
+let inMemoryToken: string | null = null
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+export function getAuthToken(): string | null {
+  if (inMemoryToken) {
+    return inMemoryToken
+  }
+
+  if (!canUseStorage()) {
+    return null
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored) {
+    inMemoryToken = stored
+    return stored
+  }
+
+  return null
+}
+
+export function setAuthToken(token: string | null) {
+  inMemoryToken = token
+
+  if (!canUseStorage()) {
+    return
+  }
+
+  if (token) {
+    window.localStorage.setItem(STORAGE_KEY, token)
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY)
+  }
+}
+
+export function clearAuthToken() {
+  setAuthToken(null)
+}

--- a/grail-client/src/main.tsx
+++ b/grail-client/src/main.tsx
@@ -4,12 +4,15 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './features/auth/AuthContext'
 import { queryClient } from './lib/queryClient.ts'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
       {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- add an authentication context, API helpers, and token persistence to manage sign-in state
- surface signup/login/logout UI inside the app shell with responsive styling
- wrap the router with the auth provider and attach bearer tokens to API requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b0c7f9a8832892eff12f383970ac