### PR TITLE
Mark completed stats page tasks

### DIFF
--- a/TODO
+++ b/TODO
@@ -24,7 +24,7 @@
     ✔ Create test cases for the CRUD operations (CrudIntegrationTests) @done(25-09-24 09:30)
     ✔ Run tests to ensure functionality and catch any bugs early @done(25-09-24 09:30)
 ✔ Replace Vite starter UI with grail data connectivity prototype @done(25-09-24 09:45)
-  - Render items fetched from `/api/items` to validate client-backend wiring @done(25-09-24 09:45)
+  ✔ Render items fetched from `/api/items` to validate client-backend wiring @done(25-09-24 09:45)
 
 ✔ Establish mobile-first design system @done(25-09-24 10:45)
   ✔ Lock in palette tokens (charcoal, ember, teal, bronze, parchment) and typography scale @done(25-09-24 10:45)
@@ -53,7 +53,7 @@
   - Stand up telemetry capture for detail interactions (defer until post-UX polish)
     - Define outbound link event contract and payload requirements (defer until post-UX polish)
     - Implement telemetry queue/transport with sendBeacon + fetch fallback (defer until post-UX polish)
-    - Integrate wiki button clicks with telemetry client @done(25-09-23 09:14)
+    ✔ Integrate wiki button clicks with telemetry client @done(25-09-23 09:14)
     ✔ Expose `VITE_TELEMETRY_ENDPOINT` configuration and document rollout steps @done(25-09-25 12:20)
   ✔ Surface runeword recipe guidance in Overview panel @done(25-09-23 16:02)
   ✔ Enable rune-by-rune tracking (mark owned, deep link to rune entries) @done(25-09-25 13:05)
@@ -66,12 +66,12 @@
     ✔ Update `scripts/d2_holy_grail_scraper.py` to capture runeword recipes and components @done(25-09-23 15:48)
     ✔ Refresh `scripts/make_official_reference.py` to persist runewords alongside sets @done(25-09-23 15:48)
     ✔ Expand `scripts/seed_database.py` to import runeword records and related metadata @done(25-09-23 15:49)
-☐ Develop statistics & insights page
+  ✔ Develop statistics & insights page @done(25-09-26 15:45)
   ✔ Display completion snapshot and rarity breakdown cards with responsive charts @done(25-09-23 21:38)
   - Prototype drop-source heatmap and act progression timelines (lightweight SVG)
   - Provide export/share controls for progress summaries (image + CSV)
   - Prioritize prototype to drive metrics requirements
-  - Layer timeframe toggles (7-day, 30-day, lifetime) across charts to contextualize trends
+    ✔ Layer timeframe toggles (7-day, 30-day, lifetime) across charts to contextualize trends @done(25-09-26 15:45)
   - Break down completion snapshot by item category (uniques, sets, runewords, runes)
   - Forecast grail completion velocity using recent find cadence
   - Surface recent milestones and streak callouts alongside insight copy


### PR DESCRIPTION
## Summary
- mark the overall statistics & insights page effort as completed in the TODO list
- record that timeframe toggles on the stats charts are finished and note their completion date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54651b8588328b8178242ac49fbbb