### PR TITLE
Fix ItemsPage log timestamp format

### DIFF
--- a/grail-client/src/features/items/ItemsPage.tsx
+++ b/grail-client/src/features/items/ItemsPage.tsx
@@ -243,7 +243,7 @@ function ItemsPage() {
       }
 
       if (found) {
-        const timestamp = new Date().toISOString().replace(/Z$/, '')
+        const timestamp = new Date().toISOString()
         return createUserItem({
           userId,
           itemId,


### PR DESCRIPTION
## Summary
- send ISO-8601 timestamps with timezone when logging grail finds so the backend accepts authenticated mutations

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68e367f8549883288f7566c594930744